### PR TITLE
Bump node version for semantic-release

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 18.x]
+        node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Use Node.js 18.16.0
+      - name: Use Node.js 14.18
         uses: actions/setup-node@v1
         with:
-          node-version: '18.16.0'
+          node-version: '14.18'
       - run: npm install
       - run: npm run semantic-release
         env:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 18.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Use Node.js 14.18
+      - name: Use Node.js 18.16.0
         uses: actions/setup-node@v1
         with:
-          node-version: '14.18'
+          node-version: '18.16.0'
       - run: npm install
       - run: npm run semantic-release
         env:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "path-browserify": "^1.0.1",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
-    "semantic-release": "^21.0.2"
+    "semantic-release": "^17.4.7"
   }
 }


### PR DESCRIPTION
Bump node version up to 18.16.0 to satisfy semantic-release requirments