### PR TITLE
FEATURE-RELEASE:support for actionJSON Photoshop API

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@adobe/aio-lib-photoshop-api": "^1.0.0",
+    "@adobe/aio-lib-photoshop-api": "^1.0.1",
     "@adobe/jwt-auth": "^2.0.0",
     "@aws-sdk/client-cognito-identity": "^3.235.0",
     "@aws-sdk/client-s3": "^3.235.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@adobe/aio-lib-photoshop-api": "^1.0.1",
+    "@adobe/aio-lib-photoshop-api": "^1.1.0",
     "@adobe/jwt-auth": "^2.0.0",
     "@aws-sdk/client-cognito-identity": "^3.235.0",
     "@aws-sdk/client-s3": "^3.235.0",

--- a/src/sample/psapi/14_applyPhotoshopActionsJson.js
+++ b/src/sample/psapi/14_applyPhotoshopActionsJson.js
@@ -29,12 +29,12 @@ async function main() {
   
     const options = {
       actionJSON: [
-        {"_obj":"traceContour","edge":{"_enum":"contourEdge","_value":"upper"},"level":148},
-        {"_obj":"placeEvent","freeTransformCenterState":{"_enum":"quadCenterState","_value":"QCSAverage"},"height":{"_unit":"percentUnit","_value":51.83142658062201},"null":{"_kind":"local","_path":"ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0"},"offset":{"_obj":"offset","horizontal":{"_unit":"pixelsUnit","_value":298.34811239846806},"vertical":{"_unit":"pixelsUnit","_value":127.16503382715794}},"replaceLayer":{"_obj":"placeEvent","to":{"_id":5,"_ref":"layer"}},"width":{"_unit":"percentUnit","_value":51.83142658062201}}
+        {'_obj':'traceContour','edge':{'_enum':'contourEdge','_value':'upper'},'level':148},
+        {'_obj':'placeEvent','freeTransformCenterState':{'_enum':'quadCenterState','_value':'QCSAverage'},'height':{'_unit':'percentUnit','_value':51.83142658062201},'null':{'_kind':'local','_path':'ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0'},'offset':{'_obj':'offset','horizontal':{'_unit':'pixelsUnit','_value':298.34811239846806},'vertical':{'_unit':'pixelsUnit','_value':127.16503382715794}},'replaceLayer':{'_obj':'placeEvent','to':{'_id':5,'_ref':'layer'}},'width':{'_unit':'percentUnit','_value':51.83142658062201}}
       ],
       additionalImages: [
         {
-          href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input01.jpg',
+          href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input02.jpg',
           storage: 'adobe'
         }
       ]

--- a/src/sample/psapi/14_applyPhotoshopActionsJson.js
+++ b/src/sample/psapi/14_applyPhotoshopActionsJson.js
@@ -18,7 +18,7 @@ async function main() {
 
     const input = {
       href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input03.jpg',
-      storage: 'adobe'
+      storage: 'external'
     }
   
     const output = {
@@ -27,15 +27,75 @@ async function main() {
       type: sdk.psApiLib.MimeType.PSD
     }
   
+    /*
+      actionJson performs:
+      - apply traceContour filter to the original image
+      - place the additional image in a new layer (note the placeholder ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0 for path field) and resize
+      - rename the newly created layer
+    */
     const options = {
       actionJSON: [
-        {'_obj':'traceContour','edge':{'_enum':'contourEdge','_value':'upper'},'level':148},
-        {'_obj':'placeEvent','freeTransformCenterState':{'_enum':'quadCenterState','_value':'QCSAverage'},'height':{'_unit':'percentUnit','_value':51.83142658062201},'null':{'_kind':'local','_path':'ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0'},'offset':{'_obj':'offset','horizontal':{'_unit':'pixelsUnit','_value':298.34811239846806},'vertical':{'_unit':'pixelsUnit','_value':127.16503382715794}},'replaceLayer':{'_obj':'placeEvent','to':{'_id':5,'_ref':'layer'}},'width':{'_unit':'percentUnit','_value':51.83142658062201}}
+        {
+          '_obj': 'traceContour',
+          'edge': {
+            '_enum': 'contourEdge',
+            '_value': 'upper'
+          },
+          'level': 148
+        },
+        {
+          '_obj': 'placeEvent',
+          'freeTransformCenterState': {
+            '_enum': 'quadCenterState',
+            '_value': 'QCSAverage'
+          },
+          'height': {
+            '_unit': 'percentUnit',
+            '_value': 51.83142658062201
+          },
+          'null': {
+            '_kind': 'local',
+            '_path': 'ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0'
+          },
+          'offset': {
+            '_obj': 'offset',
+            'horizontal': {
+              '_unit': 'pixelsUnit',
+              '_value': 298.34811239846806
+            },
+            'vertical': {
+              '_unit': 'pixelsUnit',
+              '_value': 127.16503382715794
+            }
+          },
+          'replaceLayer': {
+            '_obj': 'placeEvent',
+            'to': {
+              '_id': 5,
+              '_ref': 'layer'
+            }
+          },
+          'width': {
+            '_unit': 'percentUnit',
+            '_value': 51.83142658062201
+          }
+        },
+        {
+          '_obj': 'set',
+          '_target': [{
+            '_enum': 'ordinal',
+            '_ref': 'layer'
+          }],
+          'to': {
+            '_obj': 'layer',
+            'name': 'Overlay'
+          }
+        }
       ],
       additionalImages: [
         {
           href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input02.jpg',
-          storage: 'adobe'
+          storage: 'external'
         }
       ]
     }
@@ -43,7 +103,7 @@ async function main() {
     const job = await client.applyPhotoshopActionsJson(input, output, options)
     console.log(`${job.isDone()} - ${job.jobId}`)
     console.log(`Response: ${JSON.stringify(job,null,2)}`)
-    console.log(`Output File: ${await awsLib.getSignedUrl('getObject', 'output/test13.png')}\n`)
+    console.log(`Output File: ${await awsLib.getSignedUrl('getObject', 'output/test14.png')}\n`)
 
   } catch (e) {
     console.error(e)

--- a/src/sample/psapi/14_applyPhotoshopActionsJson.js
+++ b/src/sample/psapi/14_applyPhotoshopActionsJson.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 Adobe
+All Rights Reserved.
+
+NOTICE: Adobe permits you to use, modify, and distribute this file in
+accordance with the terms of the Adobe license agreement accompanying
+it.
+*/
+
+const awsLib = require('../../lib/awsLib')
+const sdk = require('../../../config/config')
+
+main()
+
+async function main() {
+  try {
+    const client = await sdk.initSDK()
+
+    const input = {
+      href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input03.jpg',
+      storage: 'adobe'
+    }
+  
+    const output = {
+      href: await awsLib.getSignedUrl('putObject', 'output/test14.png'),
+      storage: sdk.psApiLib.Storage.EXTERNAL,
+      type: sdk.psApiLib.MimeType.PSD
+    }
+  
+    const options = {
+      actionJSON: [
+        {"_obj":"traceContour","edge":{"_enum":"contourEdge","_value":"upper"},"level":148},
+        {"_obj":"placeEvent","freeTransformCenterState":{"_enum":"quadCenterState","_value":"QCSAverage"},"height":{"_unit":"percentUnit","_value":51.83142658062201},"null":{"_kind":"local","_path":"ACTION_JSON_OPTIONS_ADDITIONAL_IMAGES_0"},"offset":{"_obj":"offset","horizontal":{"_unit":"pixelsUnit","_value":298.34811239846806},"vertical":{"_unit":"pixelsUnit","_value":127.16503382715794}},"replaceLayer":{"_obj":"placeEvent","to":{"_id":5,"_ref":"layer"}},"width":{"_unit":"percentUnit","_value":51.83142658062201}}
+      ],
+      additionalImages: [
+        {
+          href: 'https://raw.githubusercontent.com/adobe/adobe-photoshop-api-sdk/main/testfiles/input/input01.jpg',
+          storage: 'adobe'
+        }
+      ]
+    }
+  
+    const job = await client.applyPhotoshopActionsJson(input, output, options)
+    console.log(`${job.isDone()} - ${job.jobId}`)
+    console.log(`Response: ${JSON.stringify(job,null,2)}`)
+    console.log(`Output File: ${await awsLib.getSignedUrl('getObject', 'output/test13.png')}\n`)
+
+  } catch (e) {
+    console.error(e)
+  }
+}


### PR DESCRIPTION
Adobe introduced actionJSON service, which allows for execution of Photoshop actions in JSON format. See more details https://developer.adobe.com/photoshop/photoshop-api-docs/api/#tag/Photoshop/operation/actionJSON

## Description

- Bumped up @adobe/aio-lib-photoshop-api version 
- Added a sample code for actionJson API

## Motivation and Context

Since actionJSON supports Photoshop actions in JSON format, which is plain text, it offers more flexibility for Photoshop API users and allows for easy integration of Photoshop API with their workflows.

## How Has This Been Tested?

- Tested manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [  ] All new and existing tests passed.
